### PR TITLE
Fix Austrian trustlist URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ credits:
 https://greencheck.gv.at/
 
 source:
-https://greencheck.gv.at/api/masterdata
+https://dgc-trust.qr.gv.at/trustlist
 
 # netherlands
 [![Renew Trustlist NL](https://github.com/section42/hcert-trustlist-mirror/actions/workflows/trustlist-NL.yml/badge.svg)](https://github.com/section42/hcert-trustlist-mirror/actions/workflows/trustlist-NL.yml)


### PR DESCRIPTION
It got changed to the new URL in the download script via https://github.com/section42/hcert-trustlist-mirror/commit/650ce8cb8daba3be73e061a9745668b58cffbd83 but not in the README